### PR TITLE
Refactor path handling for imports to use POSIX format

### DIFF
--- a/src/workspace/codebase/make-directory/index.ts
+++ b/src/workspace/codebase/make-directory/index.ts
@@ -1,18 +1,18 @@
-import { basename, dirname, join } from 'path';
+import { basename, dirname, posix } from 'path';
 
 export default (codebase: CodebaseType, file: FileContainerType) => {
   const filename = basename(file.pathname);
 
   const filenamePieces = filename.split('.');
-  const subfolder = filenamePieces[0];
+  const fileBaseName = filenamePieces[0];
 
-  if (subfolder === 'index') {
+  if (fileBaseName === 'index') {
     return file.pathname;
   }
 
   const directory = dirname(file.pathname);
   const newExtension = filenamePieces.slice(1).join('.');
-  const newSrc = join(directory, subfolder, `index.${newExtension}`);
+  const newSrc = posix.join(directory, fileBaseName, `index.${newExtension}`);
   codebase.files[newSrc] = codebase.files[file.pathname];
   delete codebase.files[file.pathname];
   file.pathname = newSrc;


### PR DESCRIPTION
This PR refactors the path handling in the codebase to ensure POSIX format compatibility. Replaced `join` with `posix.join` for consistent POSIX path formatting.

